### PR TITLE
Add quotes around entry value

### DIFF
--- a/lua/telescope/_extensions/cder.lua
+++ b/lua/telescope/_extensions/cder.lua
@@ -72,7 +72,9 @@ local function run()
           opts.command_executer,
           opts.previewer_command
             .. ' '
+            .. '"'
             .. entry.value
+            .. '"'
             .. ' | '
             .. opts.pager_command,
         })


### PR DESCRIPTION
Without the quotes a file/directory with a space in its name gets interpreted as multiple paths by the previewer causing an error