### PR TITLE
Allow custom entry_value transform function

### DIFF
--- a/lua/telescope/_extensions/cder.lua
+++ b/lua/telescope/_extensions/cder.lua
@@ -34,6 +34,10 @@ local opts = {
   --   previewer_command = 'exa -a --icons'
   previewer_command = 'ls -a',
 
+  entry_value_fn = function(entry_value)
+    return '"' .. entry_value .. '"'
+  end,
+
   -- The command used to page directory previews. Defaults to bat.
   -- Receives the output of the previewer_command as input.
   -- Example without bat:
@@ -96,9 +100,7 @@ local function run(o)
           o.command_executer,
           o.previewer_command
             .. ' '
-            .. '"'
-            .. entry.value
-            .. '"'
+            .. o.entry_value_fn(entry.value)
             .. ' | '
             .. o.pager_command,
         })


### PR DESCRIPTION
I use `exa` through WSL, but `fd` in Windows, which means I have to transform the Windows file path into a Unix-style path before it gets to exa.

This PR provides a way for me to do this without affecting default functionality, also increasing general extensibility.

Cheers